### PR TITLE
Fixed persistence docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To include persistence, create a new persistence object (this must be a complian
   });
 </script>
 ```
-You can read more about how to build your own persistence plugin here: [Keen.DataTools Persistence Docs](https://github.com/keenlabs/data-tools/docs/persistence.md/).
+You can read more about how to build your own persistence plugin here: [Keen.DataTools Persistence Docs](/docs/persistence.md).
 
 ## Forking the Project to Customizing and Contribute
 


### PR DESCRIPTION
# What's this PR do?

Fixed the Persistence documentation link that was 404ing, now a relative link
# Where should the reviewer start?

Look at the README.md at the bottom of this section: https://github.com/keen/explorer#3-optionally-include-persistence
# How should this be manually tested?

See above and click 
